### PR TITLE
Suppress warnings about keep-alive messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,6 +59,10 @@ var connect = function () {
             console.log('Got new message event')
             return refreshMessages()
         }
+        //Keep-alive
+        else if (message === '#') {
+            return
+        }
 
         console.error('Unknown message:', message)
     })


### PR DESCRIPTION
Pushover periodically sends a keep-alive message, causing many warnings:

```
Unknown message: #
```

These should be silently ignored.
