### PR TITLE
Added Login and Device Registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 notifications on your desktop. It uses [node-notifier](https://github.com/mikaelbr/node-notifier) so it should work
 with many different desktop notification providers on many different operating systems.
 
-This project uses the undocumented Pushover websocket API to receive updates about new notifications. You may need
-to pay to enable the [desktop service](https://pushover.net/clients/desktop) to use this project.
+This project uses the Pushover websocket API to receive updates about new notifications. You will need
+a license for the [desktop service](https://pushover.net/clients/desktop) to use this project.
 
 ### Using it
 
@@ -15,26 +15,23 @@ First install `pushover-desktop-client` globally with `npm`
 
     npm install -g pushover-desktop-client
 
-Then set up your settings file at `~/.config/pushover-dc/settings.json`
+The first time the client runs, it will need to login to Pushover and retrieve a User Secret that will be used for all 
+future connections.  For your first run, therefore, you must provide your username and password - either in a settings file, 
+or as environment variables (easier and more secure):
 
-    {
-        "secret": "secret obtained from pushover.net"
-      , "deviceId": "device id obtained from pushover.net"
-    }
+For example
 
+    PUSHOVER_USER_EMAIL=yourname@example.com PUSHOVER_USER_PASSWORD=password pushover-desktop-client
+    
+After the first run, the `secret` and `deviceId` needed for future authentication are saved in your settings file at `~/.config/pushover-dc/settings.json`
 You can override the location of the settings file with the `PUSHOVER_SETTINGS_PATH` environment variable.
 
 Alternatively you can use `PUSHOVER_DEVICE_ID`, `PUSHOVER_SECRET`, `PUSHOVER_IMAGE_CACHE` instead of using the settings
 file at all.
 
-Now you are ready to run:
+For all future executions, you just need to run:
 
     pushover-desktop-client
-
-### Finding Your deviceId and secret
-
-I had to find mine by viewing the source over at the [desktop web client](https://client.pushover.net). At the time they
-were at the bottom of the file in the variables `Pushover.deviceId` and `Pushover.userSecret`
 
 ### Running as a service on OSX
 

--- a/bin/pushover-desktop-client
+++ b/bin/pushover-desktop-client
@@ -3,9 +3,9 @@
 var PushoverDesktopClient = require('../index.js')
   , xdg = require('xdg')
   , mkdirp = require('mkdirp')
-  , settingsPath = process.env.PUSHOVER_SETTINGS_PATH || xdg.basedir.configPath('pushover-dc/settings.json');
+  , settingsPath = process.env.PUSHOVER_SETTINGS_PATH || xdg.basedir.configPath('pushover-dc/settings.json')
 
-var settings = {};
+var settings = {}
 try {
     console.log('Attempting to load settings from', settingsPath)
     settings = require(settingsPath)
@@ -16,14 +16,14 @@ try {
 
 // New Pushover Open Client API: https://pushover.net/api/client
 
-// If the user has logged in already, and we have saved the details, we should have a USER_SECRET
-settings.userSecret = process.env.PUSHOVER_USER_SECRET || settings.userSecret;
+// If the user has logged in already, and we have saved the details, we should have a 
+settings.secret = process.env.PUSHOVER_SECRET || settings.secret;
 
-// If userSecret is missing, we need to login for the first time
-if (!settings.userSecret) {
-    doFirstLogin();
+// If secret is missing, we need to login for the first time
+if (!settings.secret) {
+    doFirstLogin()
 } else {
-    checkDeviceRegistration();
+    checkDeviceRegistration()
 }
 
 /**
@@ -51,7 +51,7 @@ function doFirstLogin() {
             process.exit(1);
         }
         // Save the User Secret
-        settings.userSecret = loginResponse.secret;
+        settings.secret = loginResponse.secret;
         // Discard the User Password
         settings.userPassword = null;
         

--- a/bin/pushover-desktop-client
+++ b/bin/pushover-desktop-client
@@ -3,8 +3,9 @@
 var PushoverDesktopClient = require('../index.js')
   , xdg = require('xdg')
   , mkdirp = require('mkdirp')
-  , settingsPath = process.env.PUSHOVER_SETTINGS_PATH || xdg.basedir.configPath('pushover-dc/settings.json')
+  , settingsPath = process.env.PUSHOVER_SETTINGS_PATH || xdg.basedir.configPath('pushover-dc/settings.json');
 
+var settings = {};
 try {
     console.log('Attempting to load settings from', settingsPath)
     settings = require(settingsPath)
@@ -13,19 +14,116 @@ try {
     //Ignoring the error, hopefully we have env vars
 }
 
-settings.deviceId = process.env.PUSHOVER_DEVICE_ID || settings.deviceId
-settings.secret = process.env.PUSHOVER_SECRET || settings.secret
-settings.imageCache = process.env.PUSHOVER_IMAGE_CACHE || settings.imageCache || xdg.basedir.cachePath('pushover-dc')
+// New Pushover Open Client API: https://pushover.net/api/client
 
-if (!settings.deviceId || !settings.secret) {
-    console.error('A secret and deviceId must be provided!')
-    console.error('View the README at https://github.com/nbrownus/pushover-desktop-client for more info')
-    process.exit(1)
+// If the user has logged in already, and we have saved the details, we should have a USER_SECRET
+settings.userSecret = process.env.PUSHOVER_USER_SECRET || settings.userSecret;
+
+// If userSecret is missing, we need to login for the first time
+if (!settings.userSecret) {
+    doFirstLogin();
+} else {
+    checkDeviceRegistration();
 }
 
-console.log('Initializing image cache directory', settings.imageCache)
-mkdirp.sync(settings.imageCache, '0755')
+/**
+ * Execute the User Login process as per API:
+ * https://pushover.net/api/client#login
+ */
+function doFirstLogin() {
+    settings.userEmail = process.env.PUSHOVER_USER_EMAIL || settings.userEmail;
+    settings.userPassword = process.env.PUSHOVER_USER_PASSWORD || settings.userPassword;
+    
+    // If either Email or Password is not set, we cannot login
+    if (!settings.userEmail || !settings.userPassword) {
+        console.error('Your Pushover Email Address and Password are required for the first login');
+        console.error('Please edit '+settingsPath+' or set PUSHOVER_USER_EMAIL and PUSHOVER_USER_PASSWORD in your environment');
+        process.exit(1);
+    }
+    
+    // Use the PushoverDesktopClient library to get the user secret
+    var pdc = new PushoverDesktopClient(settings);
+    pdc.login(settings.userEmail, settings.userPassword, function(loginResponse) {
+        // Pushover API returns status = 1 on success; other on error
+        if (loginResponse.status != 1) {
+            console.error('Login Failed: ');
+            console.error(JSON.stringify(loginResponse));
+            process.exit(1);
+        }
+        // Save the User Secret
+        settings.userSecret = loginResponse.secret;
+        // Discard the User Password
+        settings.userPassword = null;
+        
+        // Persist the configuration data
+        console.log("Saving User Secret to Settings...");
+        saveSettings(checkDeviceRegistration);
+    });
+}
 
-var pdc = new PushoverDesktopClient(settings)
+function saveSettings(nextFunction) {
+    // Persist the configuration data
+    var fs = require('fs');
+    var path = require('path');
+    
+    // If we're creating the Settings file for the first time, make sure the path exists
+    if (!fs.existsSync(settingsPath)) {
+        mkdirp.sync(path.dirname(settingsPath));
+    }
+    
+    fs.writeFile(settingsPath, JSON.stringify(settings), function (err) {
+        if (err) {
+            console.log('There has been an error saving your configuration data.');
+            console.log(err.message);
+            return;
+        }
+        console.log('Configuration saved successfully.');
+        
+        nextFunction();
+    });
+}
 
-pdc.connect()
+function checkDeviceRegistration() {
+    settings.deviceId = process.env.PUSHOVER_DEVICE_ID || settings.deviceId
+    
+    // If the deviceId is missing, we need to register the device for the first time
+    if (!settings.deviceId) {
+        registerDevice(settings);
+    } else{ 
+        startClient(settings);
+    }
+}
+
+/**
+ * Execute the Device Registration process as per the API:
+ * https://pushover.net/api/client#register
+ */
+function registerDevice() {
+    // Use the PushoverDesktopClient library to get the user secret
+    var pdc = new PushoverDesktopClient(settings);
+    pdc.register('pushover-desktop', function(registerResponse) {
+        // Pushover API returns status = 1 on success; other on error
+        if (registerResponse.status != 1) {
+            console.error('Device Registration Failed: ');
+            console.error(JSON.stringify(registerResponse));
+            process.exit(1);
+        }
+        // Save the Device ID
+        settings.deviceId = registerResponse.id;
+
+        // Persist the configuration data
+        console.log("Saving DeviceId to Settings...");
+        saveSettings(startClient);
+    });
+}
+
+function startClient() {
+    settings.imageCache = process.env.PUSHOVER_IMAGE_CACHE || settings.imageCache || xdg.basedir.cachePath('pushover-dc');
+    console.log('Initializing image cache directory', settings.imageCache);
+    mkdirp.sync(settings.imageCache, '0755');
+    
+    var pdc = new PushoverDesktopClient(settings);
+    pdc.connect();
+}
+
+

--- a/bin/pushover-desktop-client
+++ b/bin/pushover-desktop-client
@@ -14,16 +14,26 @@ try {
     //Ignoring the error, hopefully we have env vars
 }
 
+settings.deviceId = process.env.PUSHOVER_DEVICE_ID || settings.deviceId
+settings.secret = process.env.PUSHOVER_SECRET || settings.secret
+settings.imageCache = process.env.PUSHOVER_IMAGE_CACHE || settings.imageCache || xdg.basedir.cachePath('pushover-dc')
+
 // New Pushover Open Client API: https://pushover.net/api/client
-
-// If the user has logged in already, and we have saved the details, we should have a 
-settings.secret = process.env.PUSHOVER_SECRET || settings.secret;
-
-// If secret is missing, we need to login for the first time
+// We must have a user secret and a device id in order to connect
 if (!settings.secret) {
     doFirstLogin()
+} else if (!settings.deviceId) {
+    doRegisterDevice()
 } else {
-    checkDeviceRegistration()
+    startClient()
+}
+
+function startClient() {
+    console.log('Initializing image cache directory', settings.imageCache)
+    mkdirp.sync(settings.imageCache, '0755')
+    
+    var pdc = new PushoverDesktopClient(settings)
+    pdc.connect()
 }
 
 /**
@@ -31,66 +41,68 @@ if (!settings.secret) {
  * https://pushover.net/api/client#login
  */
 function doFirstLogin() {
-    settings.userEmail = process.env.PUSHOVER_USER_EMAIL || settings.userEmail;
-    settings.userPassword = process.env.PUSHOVER_USER_PASSWORD || settings.userPassword;
+    // Get User Email Address & Password - these can be set in the environment, or in the settings file
+    // Either way, they are never persisted to disk, and if they are already in the settings file, they
+    // are removed once the User Secret is retrieved.
+    settings.userEmail = process.env.PUSHOVER_USER_EMAIL || settings.userEmail
+    settings.userPassword = process.env.PUSHOVER_USER_PASSWORD || settings.userPassword
     
     // If either Email or Password is not set, we cannot login
     if (!settings.userEmail || !settings.userPassword) {
-        console.error('Your Pushover Email Address and Password are required for the first login');
-        console.error('Please edit '+settingsPath+' or set PUSHOVER_USER_EMAIL and PUSHOVER_USER_PASSWORD in your environment');
-        process.exit(1);
+        console.error('Your Pushover Email Address and Password are required for the first login')
+        console.error('Please edit '+settingsPath+' or set PUSHOVER_USER_EMAIL and PUSHOVER_USER_PASSWORD in your environment')
+        process.exit(1)
     }
     
     // Use the PushoverDesktopClient library to get the user secret
-    var pdc = new PushoverDesktopClient(settings);
+    var pdc = new PushoverDesktopClient(settings)
     pdc.login(settings.userEmail, settings.userPassword, function(loginResponse) {
         // Pushover API returns status = 1 on success; other on error
         if (loginResponse.status != 1) {
-            console.error('Login Failed: ');
-            console.error(JSON.stringify(loginResponse));
-            process.exit(1);
+            console.error('Login Failed: ')
+            console.error(JSON.stringify(loginResponse))
+            process.exit(1)
         }
         // Save the User Secret
-        settings.secret = loginResponse.secret;
-        // Discard the User Password
-        settings.userPassword = null;
+        settings.secret = loginResponse.secret
+        // Discard the User Email and Password
+        settings.userPassword = undefined
+        settings.userEmail = undefined
         
         // Persist the configuration data
-        console.log("Saving User Secret to Settings...");
-        saveSettings(checkDeviceRegistration);
-    });
+        console.log("Saving User Secret to Settings...")
+        saveSettings(checkDeviceRegistration)
+    })
 }
 
 function saveSettings(nextFunction) {
     // Persist the configuration data
-    var fs = require('fs');
-    var path = require('path');
+    var fs = require('fs')
+    var path = require('path')
     
     // If we're creating the Settings file for the first time, make sure the path exists
     if (!fs.existsSync(settingsPath)) {
-        mkdirp.sync(path.dirname(settingsPath));
+        mkdirp.sync(path.dirname(settingsPath))
     }
     
-    fs.writeFile(settingsPath, JSON.stringify(settings), function (err) {
+    fs.writeFile(settingsPath, JSON.stringify(settings, null, '\t'), function (err) {
         if (err) {
-            console.log('There has been an error saving your configuration data.');
-            console.log(err.message);
+            console.log('There has been an error saving your configuration data.')
+            console.log(err.message)
             return;
         }
-        console.log('Configuration saved successfully.');
+        console.log('Configuration saved successfully.')
         
-        nextFunction();
-    });
+        nextFunction()
+    })
 }
 
 function checkDeviceRegistration() {
-    settings.deviceId = process.env.PUSHOVER_DEVICE_ID || settings.deviceId
-    
     // If the deviceId is missing, we need to register the device for the first time
     if (!settings.deviceId) {
-        registerDevice(settings);
+        doRegisterDevice(settings)
     } else{ 
-        startClient(settings);
+        startClient(settings)
     }
 }
 
@@ -98,32 +110,25 @@ function checkDeviceRegistration() {
  * Execute the Device Registration process as per the API:
  * https://pushover.net/api/client#register
  */
-function registerDevice() {
+function doRegisterDevice() {
     // Use the PushoverDesktopClient library to get the user secret
-    var pdc = new PushoverDesktopClient(settings);
+    var pdc = new PushoverDesktopClient(settings)
     pdc.register('pushover-desktop', function(registerResponse) {
         // Pushover API returns status = 1 on success; other on error
         if (registerResponse.status != 1) {
-            console.error('Device Registration Failed: ');
-            console.error(JSON.stringify(registerResponse));
-            process.exit(1);
+            console.error('Device Registration Failed: ')
+            console.error(JSON.stringify(registerResponse))
+            process.exit(1)
         }
         // Save the Device ID
-        settings.deviceId = registerResponse.id;
+        settings.deviceId = registerResponse.id
 
         // Persist the configuration data
-        console.log("Saving DeviceId to Settings...");
-        saveSettings(startClient);
-    });
+        console.log("Saving DeviceId to Settings...")
+        saveSettings(startClient)
+    })
 }
 
-function startClient() {
-    settings.imageCache = process.env.PUSHOVER_IMAGE_CACHE || settings.imageCache || xdg.basedir.cachePath('pushover-dc');
-    console.log('Initializing image cache directory', settings.imageCache);
-    mkdirp.sync(settings.imageCache, '0755');
-    
-    var pdc = new PushoverDesktopClient(settings);
-    pdc.connect();
-}
+
 
 

--- a/index.js
+++ b/index.js
@@ -9,8 +9,8 @@ var ws = require('ws')
  * Handles everything for showing Pushover notifications, just call #connect()
  *
  * @param {Object} settings Instance configuration
+ * @param {String} settings.userSecret The user secret for your Pushover notification stream
  * @param {String} settings.deviceId The device id for your Pushover notification stream
- * @param {String} settings.secret The secret for your Pushover notification stream
  * @param {String} [settings.imageCache=null] Path to the image cache directory, used for app icons
  * @param {String} [settings.wsHost='wss://client.pushover.net/push'] Pushover websocket host to connect to
  * @param {String} [settings.iconHost='client.pushover.net'] Pushover icon host
@@ -59,7 +59,7 @@ Client.prototype.connect = function () {
         self.refreshMessages()
         self.logger.log('Websocket client connected, waiting for new messages')
         self.resetKeepAlive()
-        wsClient.send('login:' + self.settings.deviceId + ':' + self.settings.secret + '\n')
+        wsClient.send('login:' + self.settings.deviceId + ':' + self.settings.userSecret + '\n')
     })
 
     wsClient.on('message', function (event) {
@@ -143,7 +143,7 @@ Client.prototype.refreshMessages = function () {
         host: self.settings.apiHost
       , method: 'GET'
       , path: self.settings.apiPath + '/messages.json?' + querystring.stringify({
-            secret: self.settings.secret
+            secret: self.settings.userSecret
           , device_id: self.settings.deviceId
         })
     }
@@ -179,6 +179,113 @@ Client.prototype.refreshMessages = function () {
     })
 
     request.end()
+}
+
+/**
+ * Makes an https request to Pushover to get the client secret
+ */
+Client.prototype.login = function (userEmail, userPassword, callback) {
+    var self = this;
+
+    self.logger.log('Performing Login');
+
+    var options = {
+        host: self.settings.apiHost
+      , method: 'POST'
+      , path: self.settings.apiPath + '/users/login.json'
+    };
+    
+    var postData = querystring.stringify({
+        'email' : userEmail,
+        'password' : userPassword
+    });
+
+    var request = self.https.request(options, function (response) {
+        var finalData = '';
+
+        response.on('data', function (data) {
+            finalData += data.toString();
+        });
+
+        response.on('end', function () {
+            if (response.statusCode !== 200) {
+                self.logger.error('Error while logging in');
+                self.logger.error(finalData);
+                return;
+            }
+
+            try {
+                var payload = JSON.parse(finalData);
+                callback(payload);
+            } catch (error) {
+                self.logger.error('Failed to parse message payload');
+                self.logger.error(error.stack || error);
+            }
+        });
+
+    });
+
+    request.on('error', function (error) {
+        self.logger.error('Error while logging in');
+        self.logger.error(error.stack || error);
+    });
+    
+    request.write(postData);
+    request.end();
+}
+
+/**
+ * Makes an https request to Pushover to register the device
+ */
+Client.prototype.register = function (deviceName, callback) {
+    var self = this;
+
+    self.logger.log('Performing Device Registration');
+
+    var options = {
+        host: self.settings.apiHost
+      , method: 'POST'
+      , path: self.settings.apiPath + '/devices.json'
+    };
+    
+    var postData = querystring.stringify({
+        'secret' : self.settings.userSecret,
+        'name' : deviceName,
+        'os' : 'O'
+    });
+
+    var request = self.https.request(options, function (response) {
+        var finalData = '';
+
+        response.on('data', function (data) {
+            finalData += data.toString();
+        });
+
+        response.on('end', function () {
+            if (response.statusCode !== 200) {
+                self.logger.error('Error while registering device');
+                self.logger.error(finalData);
+                return;
+            }
+
+            try {
+                var payload = JSON.parse(finalData);
+                callback(payload);
+            } catch (error) {
+                self.logger.error('Failed to parse message payload');
+                self.logger.error(error.stack || error);
+            }
+        });
+
+    });
+
+    request.on('error', function (error) {
+        self.logger.error('Error while logging in');
+        self.logger.error(error.stack || error);
+    });
+    
+    request.write(postData);
+    request.end();
 }
 
 /**
@@ -349,7 +456,7 @@ Client.prototype.updateHead = function (message) {
     })
 
     request.write(querystring.stringify({
-        secret: self.settings.secret
+        secret: self.settings.userSecret
       , message: message.id
     }) + '\n')
 

--- a/index.js
+++ b/index.js
@@ -240,7 +240,7 @@ Client.prototype.login = function (userEmail, userPassword, callback) {
 Client.prototype.register = function (deviceName, callback) {
     var self = this
     
-    self.settings.logger.log('Performing Device Registration')
+    self.logger.log('Performing Device Registration')
 
     var options = {
         host: self.settings.apiHost

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ var ws = require('ws')
  * Handles everything for showing Pushover notifications, just call #connect()
  *
  * @param {Object} settings Instance configuration
- * @param {String} settings.userSecret The user secret for your Pushover notification stream
+ * @param {String} settings.secret The user secret for your Pushover notification stream
  * @param {String} settings.deviceId The device id for your Pushover notification stream
  * @param {String} [settings.imageCache=null] Path to the image cache directory, used for app icons
  * @param {String} [settings.wsHost='wss://client.pushover.net/push'] Pushover websocket host to connect to
@@ -59,7 +59,7 @@ Client.prototype.connect = function () {
         self.refreshMessages()
         self.logger.log('Websocket client connected, waiting for new messages')
         self.resetKeepAlive()
-        wsClient.send('login:' + self.settings.deviceId + ':' + self.settings.userSecret + '\n')
+        wsClient.send('login:' + self.settings.deviceId + ':' + self.settings.secret + '\n')
     })
 
     wsClient.on('message', function (event) {
@@ -143,7 +143,7 @@ Client.prototype.refreshMessages = function () {
         host: self.settings.apiHost
       , method: 'GET'
       , path: self.settings.apiPath + '/messages.json?' + querystring.stringify({
-            secret: self.settings.userSecret
+            secret: self.settings.secret
           , device_id: self.settings.deviceId
         })
     }
@@ -249,7 +249,7 @@ Client.prototype.register = function (deviceName, callback) {
     }
     
     var postData = querystring.stringify({
-        'secret' : self.settings.userSecret
+        'secret' : self.settings.secret
       , 'name' : deviceName
       , 'os' : 'O'
     })
@@ -456,7 +456,7 @@ Client.prototype.updateHead = function (message) {
     })
 
     request.write(querystring.stringify({
-        secret: self.settings.userSecret
+        secret: self.settings.secret
       , message: message.id
     }) + '\n')
 

--- a/index.js
+++ b/index.js
@@ -185,107 +185,107 @@ Client.prototype.refreshMessages = function () {
  * Makes an https request to Pushover to get the client secret
  */
 Client.prototype.login = function (userEmail, userPassword, callback) {
-    var self = this;
+    var self = this
 
-    self.logger.log('Performing Login');
+    self.logger.log('Performing Login')
 
     var options = {
         host: self.settings.apiHost
       , method: 'POST'
       , path: self.settings.apiPath + '/users/login.json'
-    };
+    }
     
     var postData = querystring.stringify({
-        'email' : userEmail,
-        'password' : userPassword
-    });
+        'email' : userEmail
+      , 'password' : userPassword
+    })
 
     var request = self.https.request(options, function (response) {
-        var finalData = '';
+        var finalData = ''
 
         response.on('data', function (data) {
-            finalData += data.toString();
+            finalData += data.toString()
         });
 
         response.on('end', function () {
             if (response.statusCode !== 200) {
-                self.logger.error('Error while logging in');
-                self.logger.error(finalData);
-                return;
+                self.logger.error('Error while logging in')
+                self.logger.error(finalData)
+                return
             }
 
             try {
-                var payload = JSON.parse(finalData);
-                callback(payload);
+                var payload = JSON.parse(finalData)
+                callback(payload)
             } catch (error) {
-                self.logger.error('Failed to parse message payload');
-                self.logger.error(error.stack || error);
+                self.logger.error('Failed to parse message payload')
+                self.logger.error(error.stack || error)
             }
-        });
+        })
 
-    });
+    })
 
     request.on('error', function (error) {
-        self.logger.error('Error while logging in');
-        self.logger.error(error.stack || error);
+        self.logger.error('Error while logging in')
+        self.logger.error(error.stack || error)
     });
     
-    request.write(postData);
-    request.end();
+    request.write(postData)
+    request.end()
 }
 
 /**
  * Makes an https request to Pushover to register the device
  */
 Client.prototype.register = function (deviceName, callback) {
-    var self = this;
-
-    self.logger.log('Performing Device Registration');
+    var self = this
+    
+    self.settings.logger.log('Performing Device Registration')
 
     var options = {
         host: self.settings.apiHost
       , method: 'POST'
       , path: self.settings.apiPath + '/devices.json'
-    };
+    }
     
     var postData = querystring.stringify({
-        'secret' : self.settings.userSecret,
-        'name' : deviceName,
-        'os' : 'O'
-    });
+        'secret' : self.settings.userSecret
+      , 'name' : deviceName
+      , 'os' : 'O'
+    })
 
     var request = self.https.request(options, function (response) {
-        var finalData = '';
+        var finalData = ''
 
         response.on('data', function (data) {
-            finalData += data.toString();
-        });
+            finalData += data.toString()
+        })
 
         response.on('end', function () {
             if (response.statusCode !== 200) {
-                self.logger.error('Error while registering device');
-                self.logger.error(finalData);
-                return;
+                self.logger.error('Error while registering device')
+                self.logger.error(finalData)
+                return
             }
 
             try {
-                var payload = JSON.parse(finalData);
-                callback(payload);
+                var payload = JSON.parse(finalData)
+                callback(payload)
             } catch (error) {
-                self.logger.error('Failed to parse message payload');
-                self.logger.error(error.stack || error);
+                self.logger.error('Failed to parse message payload')
+                self.logger.error(error.stack || error)
             }
         });
 
     });
 
     request.on('error', function (error) {
-        self.logger.error('Error while logging in');
-        self.logger.error(error.stack || error);
+        self.logger.error('Error while logging in')
+        self.logger.error(error.stack || error)
     });
     
-    request.write(postData);
-    request.end();
+    request.write(postData)
+    request.end()
 }
 
 /**


### PR DESCRIPTION
I've added functionality to handle the proper Login and Device Registration procedures documented in the Pushover Open Client API: https://pushover.net/api/client

Initially, the user should save the userEmail and userPassword in either the settings json or in environment variables.  Using these details, the library will now fetch the userSecret needed, and register a new deviceId; both of these values are then saved back to the settings json.

The user's password is never saved to disk - only the userSecret and deviceId are saved, and once these are available the rest of the package continues to work exactly as per your original design.
